### PR TITLE
Changed the IMAGEBUILDER_URL and added the backported devices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ endif
 parse_install_target:
 ifeq ($(INSTALL_TARGET),piratebox)
 #This has to be aligned with current piratebox version :(
-ADDITIONAL_PACKAGE_IMAGE_URL:="http://piratebox.aod-rpg.de/piratebox_ws_1.0_img.tar.gz"
+ADDITIONAL_PACKAGE_IMAGE_URL:="http://beta.openwrt.piratebox.de/piratebox_ws_1.0_img.tar.gz"
 ADDITIONAL_PACKAGE_FILE:=piratebox_ws_1.0_img.tar.gz
 TARGET_PACKAGE="extendRoot-$(INSTALL_TARGET)"
 IMAGEPREFIX:=$(INSTALL_TARGET)


### PR DESCRIPTION
The IMAGEBUILDER_URL now points to my OpenWrt AA repo with some newly backported devices and some additional bugfixes. Currently I only have the ar71xx imagebuilder available.

Additionally there are some extra targets added to the Makefile for the new devices.

updated dev.openwrt.piratebox.de to beta.openwrt.piratebox.de
