### PR TITLE
Changed the IMAGEBUILDER_URL and added the backported devices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VERSION_FILE=files/etc/pbx_custom_image
 VERSION_TAG="PBX_Image_2.0"
-IMAGEBUILDER_URL="http://downloads.openwrt.org/attitude_adjustment/12.09/ar71xx/generic/OpenWrt-ImageBuilder-ar71xx_generic-for-linux-i486.tar.bz2"
+IMAGEBUILDER_URL="https://github.com/FriedZombie/OpenWrt_Attitude-Adjustment_backports/releases/download/V0.1/OpenWrt-ImageBuilder-opkg618-fw2-ar71xx_generic-for-linux-i486.tar.bz2"
 WGET=wget
 DL_FILE="ImageBuilder.tar.bz2"
 IB_FOLDER=OpenWrt-ImageBuilder-ar71xx_generic-for-linux-i486
@@ -28,7 +28,7 @@ imagebuilder: $(IB_FOLDER)
 %.bin: 
 	cp $(IB_FOLDER)/bin/ar71xx/$@ ./
 
-TLMR3020 TLMR3040 TLWR703 TLWR842 TLWR1043 :  
+TLMR3020 TLMR3040 TLMR10U TLMR11U TLMR13U TLWR703 TLWR842 TLWR1043 :
 	cd $(IB_FOLDER)  &&	make image PROFILE="$@" PACKAGES=$(GENERAL_PACKAGES) FILES=$(FILES_FOLDER)
 
 ############## uncommented. We can reuse one until we need different packages
@@ -39,11 +39,17 @@ TLMR3020 TLMR3040 TLWR703 TLWR842 TLWR1043 :
 #	cd $(IB_FOLDER) &&	make image PROFILE="$@" PACKAGES=$(GENERAL_PACKAGES) FILES=$(FILES_FOLDER)
 
 
-all: imagebuilder MR3020 MR3040 WR703N WR842 WR1043
+all: imagebuilder MR3020 MR3040 MR10U MR11U MR13U WR703N WR842 WR1043
 
 MR3020: TLMR3020 openwrt-ar71xx-generic-tl-mr3020-v1-squashfs-factory.bin
 
-MR3040: TLMR3040 openwrt-ar71xx-generic-tl-mr3040-v1-squashfs-factory.bin
+MR3040: TLMR3040 openwrt-ar71xx-generic-tl-mr3040-v1-squashfs-factory.bin openwrt-ar71xx-generic-tl-mr3040-v2-squashfs-factory.bin
+
+MR10U: TLMR10U openwrt-ar71xx-generic-tl-mr10u-v1-squashfs-factory.bin
+
+MR11U: TLMR11U openwrt-ar71xx-generic-tl-mr11u-v1-squashfs-factory.bin openwrt-ar71xx-generic-tl-mr11u-v2-squashfs-factory.bin
+
+MR13U: TLMR13U openwrt-ar71xx-generic-tl-mr13u-v1-squashfs-factory.bin
 
 WR703N: TLWR703 openwrt-ar71xx-generic-tl-wr703n-v1-squashfs-factory.bin
 


### PR DESCRIPTION
The IMAGEBUILDER_URL now points to my OpenWrt AA repo with some newly backported devices and some additional bugfixes.

Additionally there are some extra targets added to the Makefile for the new devices.
