### PR TITLE
Added modified Makefile and .mk profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,23 +9,33 @@ VERSION_FILE=files/etc/pbx_custom_image
 VERSION_TAG="PBX_auto_Image_2.5"
 
 # Imagebuilder related configuration
-LEDE_VERSION=17.01.1
+LEDE_VERSION=17.01.2
 
 # Add a prefix to allow box installer to find these images, too...
 #  .. LEDE and OpenWrt will join in future, the the name lede_
 #  in the images will vanish, so we can revert it here back without
 #  touching the autoflash feature
-OPENWRT_COMP="openwrt_"
+OPENWRT_COMP="openwrt-"
 
 include ${CURDIR}/include/$(TARGET)-$(TARGET_TYPE).mk
 
+SNAPSHOT=false
+ifeq ($(SNAPSHOT), true)
+#SNAPSHOT SETTINGS
+IMAGEBUILDER_URL="https://downloads.lede-project.org/snapshots/targets/$(TARGET)/$(TARGET_TYPE)/lede-imagebuilder-$(TARGET)-$(TARGET_TYPE).Linux-x86_64.tar.xz"
+IMAGE_BUILD_FOLDER=$(HERE)/lede-imagebuilder-$(TARGET)-$(TARGET_TYPE).Linux-x86_64/
+else
+#DEFAULT LEDE
 IMAGEBUILDER_URL="https://downloads.lede-project.org/releases/$(LEDE_VERSION)/targets/$(TARGET)/$(TARGET_TYPE)/lede-imagebuilder-$(LEDE_VERSION)-$(TARGET)-$(TARGET_TYPE).Linux-x86_64.tar.xz"
+IMAGE_BUILD_FOLDER=$(HERE)/lede-imagebuilder-$(LEDE_VERSION)-$(TARGET)-$(TARGET_TYPE).Linux-x86_64/
+endif
+
 IMAGE_BUILDER_FILE="ImageBuilder-$(TARGET)_$(TARGET_TYPE).tar.xz"
 LEDE_REPOSITORY_PREFIX="reboot"
 
 
-IMAGE_BUILD_REPOSITORY?=http://development.piratebox.de/all/packages
-IMAGE_BUILD_FOLDER=$(HERE)/lede-imagebuilder-$(LEDE_VERSION)-$(TARGET)-$(TARGET_TYPE).Linux-x86_64/
+IMAGE_BUILD_REPOSITORY?=http://development.piratebox.de/all/
+
 
 # Prefix for the installer directory
 #
@@ -58,16 +68,16 @@ OPKG_INSTALL_DEST:=$(IPKG_OFFLINE_ROOT)/$(EXT_FOLDER)
 # This has to be aligned with current piratebox version :(
 parse_install_target:
 ifeq ($(INSTALL_TARGET), piratebox)
-ADDITIONAL_PACKAGE_IMAGE_URL:="http://stable.openwrt.piratebox.de/piratebox_images/piratebox_ws_1.2_img.tar.gz"
-ADDITIONAL_PACKAGE_FILE:=piratebox_ws_1.2_img.tar.gz
+ADDITIONAL_PACKAGE_IMAGE_URL:="http://development.piratebox.de/piratebox_images/piratebox_ws_1.2_img.tar.gz"
+ADDITIONAL_PACKAGE_FILE:=piratebox-ws_1.2_img.tar.gz
 GENERAL_PACKAGES:=$(GENERAL_PACKAGES) pbxmesh
-TARGET_PACKAGE=extendRoot-$(INSTALL_TARGET) piratebox-mod-imageboard extendRoot-minidlna  extendRoot-avahi extendRoot-dbus extendRoot-avahi-tools
-AUTO_PACKAGE_ORDER="extendRoot-dbus extendRoot-avahi extendRoot-avahi-tools extendRoot-piratebox piratebox-mod-imageboard extendRoot-minidlna"
+TARGET_PACKAGE=extendRoot-$(INSTALL_TARGET) piratebox-mod-imageboard extendRoot-minidlna  extendRoot-avahi extendRoot-dbus extendRoot-avahi-tools extendRoot-openssh-sftp-server
+AUTO_PACKAGE_ORDER="extendRoot-dbus extendRoot-openssh-sftp-server extendRoot-avahi extendRoot-avahi-tools extendRoot-piratebox piratebox-mod-imageboard extendRoot-minidlna"
 KAREHA_RELEASE:=kareha_3.1.4.zip
-endif 
+endif
 ifeq ($(INSTALL_TARGET),librarybox)
-ADDITIONAL_PACKAGE_IMAGE_URL:="http://downloads.librarybox.us/librarybox_2.1_img.tar.gz"
-ADDITIONAL_PACKAGE_FILE=librarybox_2.1_img.tar.gz
+ADDITIONAL_PACKAGE_IMAGE_URL:="http://downloads.librarybox.us/librarybox_2.2_img.tar.gz"
+ADDITIONAL_PACKAGE_FILE=librarybox_2.2_img.tar.gz
 TARGET_PACKAGE=extendRoot-$(INSTALL_TARGET) extendRoot-minidlna extendRoot-avahi extendRoot-avahi-tools extendRoot-dbus
 AUTO_PACKAGE_ORDER="extendRoot-dbus extendRoot-avahi extendRoot-avahi-tools extendRoot-librarybox"
 # Add additional packages to image build directly on root
@@ -123,7 +133,7 @@ $(INSTALL_ADDITIONAL_PACKAGE_FILE): $(ADDITIONAL_PACKAGE_FILE)
 $(INSTALLER_CONF):
 	 printf '%b\n' "$(AUTO_PACKAGE_ORDER)" > $@
 
-mount_ext: 
+mount_ext:
 	mkdir -p $(DEST_IMAGE_FOLDER)
 	gunzip $(IMAGE_FILE) -c > $(SRC_IMAGE_UNPACKED)
 	sudo mount -o loop,rw,sync $(SRC_IMAGE_UNPACKED) $(DEST_IMAGE_FOLDER)
@@ -131,7 +141,7 @@ mount_ext:
 transfer_data_to_ext:
 	sudo cp -rv --preserve=mode,links $(OPKG_INSTALL_DEST)/* $(DEST_IMAGE_FOLDER)
 
-umount_ext: 
+umount_ext:
 	sudo umount $(DEST_IMAGE_FOLDER)
 
 create_cache: $(IMAGE_FILE) $(OPKG_INSTALL_DEST) $(INSTALL_CACHE_FOLDER)
@@ -147,7 +157,7 @@ $(INSTALL_OPENWRT_IMAGE_FILE):
 # Repository-Informations
 # On the live image it is called attitiude_adjustment... on the imagebuild - yeah u know
 cache_package_list:
-	cd $(IPKG_STATE_DIR)/lists/ ; ls -1 piratebox $(LEDE_REPOSITORY_PREFIX)* | while read packagefile ; do cp -v $(IPKG_STATE_DIR)/lists/$$packagefile $(INSTALL_CACHE_FOLDER)/Package.gz_$$packagefile ; done 
+	cd $(IPKG_STATE_DIR)/lists/ ; ls -1 piratebox $(LEDE_REPOSITORY_PREFIX)* | while read packagefile ; do cp -v $(IPKG_STATE_DIR)/lists/$$packagefile $(INSTALL_CACHE_FOLDER)/Package.gz_$$packagefile ; done
 
 $(INSTALL_ZIP):
 	cd $(INSTALL_PREFIX) && zip -r9 $@ ./install
@@ -166,16 +176,16 @@ endif
 
 prepare_install_zip: create_cache cache_package_list $(INSTALLER_CONF) mount_ext transfer_data_to_ext umount_ext $(INSTALL_OPENWRT_IMAGE_FILE) $(INSTALL_ADDITIONAL_PACKAGE_FILE)
 ifeq ($(INSTALL_TARGET), piratebox)
-	if [ ! -e $(KAREHA_RELEASE) ]; then wget -c http://wakaba.c3.cx/releases/$(KAREHA_RELEASE) -O $(KAREHA_RELEASE); fi;
+	if [ ! -e $(KAREHA_RELEASE) ]; then wget -c http://wakaba.c3.cx/releases/Kareha/$(KAREHA_RELEASE) -O $(KAREHA_RELEASE); fi;
 	cp -v $(KAREHA_RELEASE) $(INSTALL_FOLDER)
-endif 
+endif
 
 # Prepare the image builder folder
 imagebuilder: $(IMAGE_BUILD_FOLDER)
 
 # Extract the image builder
 $(IMAGE_BUILD_FOLDER): $(IMAGE_BUILDER_FILE) $(VERSION_FILE)
-	pbzip2 -cd $(IMAGE_BUILDER_FILE) | tar -xv || tar -xvf $(IMAGE_BUILDER_FILE) 
+	pbzip2 -cd $(IMAGE_BUILDER_FILE) | tar -xv || tar -xvf $(IMAGE_BUILDER_FILE)
 	echo "src/gz piratebox $(IMAGE_BUILD_REPOSITORY)" >> $(IMAGE_BUILD_FOLDER)/repositories.conf
 
 # Download the imagebuilder file
@@ -183,7 +193,7 @@ $(IMAGE_BUILDER_FILE):
 	wget -c $(IMAGEBUILDER_URL) -O $(IMAGE_BUILDER_FILE)
 
 # Create the version file
-$(VERSION_FILE): 
+$(VERSION_FILE):
 	mkdir -p files/etc
 	echo $(VERSION_TAG) > $@
 
@@ -192,17 +202,12 @@ $(VERSION_FILE):
 	cd $(IMAGE_BUILD_FOLDER) &&	make image PROFILE="$$(cat $(IMAGE_BUILD_FOLDER)/profile.build.tmp )" PACKAGES="$(GENERAL_PACKAGES)" FILES=$(FILES_FOLDER)
 ifneq ($(INSTALL_PREFIX),)
 	mkdir -p $(INSTALL_PREFIX)
-	cp $(IMAGE_BUILD_FOLDER)/bin/targets/$(TARGET)/$(TARGET_TYPE)/$@ $(INSTALL_PREFIX)/$(OPENWRT_COMP)$@
+	cp $(IMAGE_BUILD_FOLDER)/bin/targets/$(TARGET)/$(TARGET_TYPE)/*squashfs-factory.bin $(INSTALL_PREFIX)/$(OPENWRT_COMP)$@
 	cd $(INSTALL_PREFIX) && sha256sum $(OPENWRT_COMP)$@ > $(OPENWRT_COMP)$@.sha256
 else
 	cp $(IMAGE_BUILD_FOLDER)/bin/targets/$(TARGET)/$(TARGET_TYPE)/$@ ./$@
 	sha256sum $@ > $@.sha256
 endif
-
-
-
-
-
 
 distclean: clean
 	rm -rf $(IMAGE_BUILDER_FILE)

--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ $(VERSION_FILE):
 	cd $(IMAGE_BUILD_FOLDER) &&	make image PROFILE="$$(cat $(IMAGE_BUILD_FOLDER)/profile.build.tmp )" PACKAGES="$(GENERAL_PACKAGES)" FILES=$(FILES_FOLDER)
 ifneq ($(INSTALL_PREFIX),)
 	mkdir -p $(INSTALL_PREFIX)
-	cp $(IMAGE_BUILD_FOLDER)/bin/targets/$(TARGET)/$(TARGET_TYPE)/*squashfs-factory.bin $(INSTALL_PREFIX)/$(OPENWRT_COMP)$@
+	cp $(IMAGE_BUILD_FOLDER)/bin/targets/$(TARGET)/$(TARGET_TYPE)/$@ $(INSTALL_PREFIX)/$(OPENWRT_COMP)$@
 	cd $(INSTALL_PREFIX) && sha256sum $(OPENWRT_COMP)$@ > $(OPENWRT_COMP)$@.sha256
 else
 	cp $(IMAGE_BUILD_FOLDER)/bin/targets/$(TARGET)/$(TARGET_TYPE)/$@ ./$@

--- a/README.md
+++ b/README.md
@@ -52,3 +52,6 @@ During customization, the package pbxopg gets installed. This package is located
 repository above and modifies opkg.conf at the final image to use that repository too.
 
 For further information check out the [OpenWRT temp repository](https://github.com/PirateBox-Dev/openwrt-temp-repository)
+
+## SNAPSHOT CHANGES
+If you want to build a piratebox image on an lede snapshot, change the variable SNAPSHOT in the makefile and you will be able to access the snapshot imagebuilder and snapshot profiles.

--- a/include/ar71xx-generic.mk
+++ b/include/ar71xx-generic.mk
@@ -9,6 +9,7 @@ ARCH_BUILDROOT=$(ARCH)_musl-1.1.16
 all: \
 	imagebuilder \
 	GLAR150 \
+	GLAR300 \
 	INET \
 	MR3020 \
 	MR3040 \
@@ -23,6 +24,7 @@ all: \
 	WR2543 \
 	WR1043 \
 	WDR4300 \
+	WR902AC \
 	install_zip
 
 INET: \
@@ -33,27 +35,31 @@ INET: \
 GLAR150: \
 	lede-$(LEDE_VERSION)-ar71xx-generic-gl-ar150-squashfs-sysupgrade.bin
 
+GLAR300: \
+	lede-$(LEDE_VERSION)-ar71xx-generic-gl-ar300-squashfs-sysupgrade.bin  \
+	lede-$(LEDE_VERSION)-ar71xx-generic-gl-ar300m-squashfs-sysupgrade.bin
+
 MR3020: \
 	lede-$(LEDE_VERSION)-ar71xx-generic-tl-mr3020-v1-squashfs-factory.bin
 
 MR3040: \
 	lede-$(LEDE_VERSION)-ar71xx-generic-tl-mr3040-v1-squashfs-factory.bin \
-	lede-$(LEDE_VERSION)-ar71xx-generic-tl-mr3040-v2-squashfs-factory.bin 
+	lede-$(LEDE_VERSION)-ar71xx-generic-tl-mr3040-v2-squashfs-factory.bin
 
 MR3220: \
 	lede-$(LEDE_VERSION)-ar71xx-generic-tl-mr3220-v1-squashfs-factory.bin \
-	lede-$(LEDE_VERSION)-ar71xx-generic-tl-mr3220-v2-squashfs-factory.bin 
+	lede-$(LEDE_VERSION)-ar71xx-generic-tl-mr3220-v2-squashfs-factory.bin
 
 MR3420: \
 	lede-$(LEDE_VERSION)-ar71xx-generic-tl-mr3420-v1-squashfs-factory.bin \
-	lede-$(LEDE_VERSION)-ar71xx-generic-tl-mr3420-v2-squashfs-factory.bin 
+	lede-$(LEDE_VERSION)-ar71xx-generic-tl-mr3420-v2-squashfs-factory.bin
 
 MR10U: \
-	lede-$(LEDE_VERSION)-ar71xx-generic-tl-mr10u-v1-squashfs-factory.bin 
+	lede-$(LEDE_VERSION)-ar71xx-generic-tl-mr10u-v1-squashfs-factory.bin
 
 MR11U: \
 	lede-$(LEDE_VERSION)-ar71xx-generic-tl-mr11u-v1-squashfs-factory.bin \
-	lede-$(LEDE_VERSION)-ar71xx-generic-tl-mr11u-v2-squashfs-factory.bin 
+	lede-$(LEDE_VERSION)-ar71xx-generic-tl-mr11u-v2-squashfs-factory.bin
 
 MR13U: \
 	lede-$(LEDE_VERSION)-ar71xx-generic-tl-mr13u-v1-squashfs-factory.bin
@@ -84,3 +90,6 @@ WDR4300: \
 	lede-$(LEDE_VERSION)-ar71xx-generic-tl-wdr4300-v1-squashfs-factory.bin \
 	lede-$(LEDE_VERSION)-ar71xx-generic-tl-wdr4300-v1-il-squashfs-factory.bin
 
+WR902AC: \
+	lede-$(LEDE_VERSION)-ar71xx-generic-tl-wr902ac-v1-squashfs-factory.bin \
+	lede-$(LEDE_VERSION)-ar71xx-generic-tl-wr902ac-v1-squashfs-sysupgrade.bin

--- a/include/ar71xx-generic.mk
+++ b/include/ar71xx-generic.mk
@@ -91,5 +91,4 @@ WDR4300: \
 	lede-$(LEDE_VERSION)-ar71xx-generic-tl-wdr4300-v1-il-squashfs-factory.bin
 
 WR902AC: \
-	lede-$(LEDE_VERSION)-ar71xx-generic-tl-wr902ac-v1-squashfs-factory.bin \
-	lede-$(LEDE_VERSION)-ar71xx-generic-tl-wr902ac-v1-squashfs-sysupgrade.bin
+	lede-$(LEDE_VERSION)-ar71xx-generic-tl-wr902ac-v1-squashfs-factory.bin 


### PR DESCRIPTION
I added some basic snapshot support so you can build piratebox images on lede snapshots. Supported devices would be the TL-WR902AC.